### PR TITLE
Revert "libfs_avb: verifying vbmeta digest early"

### DIFF
--- a/fs_mgr/libfs_avb/fs_avb.cpp
+++ b/fs_mgr/libfs_avb/fs_avb.cpp
@@ -434,16 +434,6 @@ AvbUniquePtr AvbHandle::Open() {
     // Sets the MAJOR.MINOR for init to set it into "ro.boot.avb_version".
     avb_handle->avb_version_ = StringPrintf("%d.%d", AVB_VERSION_MAJOR, AVB_VERSION_MINOR);
 
-    // Verifies vbmeta structs against the digest passed from bootloader in kernel cmdline.
-    std::unique_ptr<AvbVerifier> avb_verifier = AvbVerifier::Create();
-    if (!avb_verifier || !avb_verifier->VerifyVbmetaImages(avb_handle->vbmeta_images_)) {
-        LERROR << "Failed to verify vbmeta digest";
-        if (!allow_verification_error) {
-            LERROR << "vbmeta digest error isn't allowed ";
-            return nullptr;
-        }
-    }
-
     // Checks whether FLAGS_VERIFICATION_DISABLED is set:
     //   - Only the top-level vbmeta struct is read.
     //   - vbmeta struct in other partitions are NOT processed, including AVB HASH descriptor(s)
@@ -454,16 +444,26 @@ AvbUniquePtr AvbHandle::Open() {
     bool verification_disabled = ((AvbVBMetaImageFlags)vbmeta_header.flags &
                                   AVB_VBMETA_IMAGE_FLAGS_VERIFICATION_DISABLED);
 
-    // Checks whether FLAGS_HASHTREE_DISABLED is set.
-    //   - vbmeta struct in all partitions are still processed, just disable
-    //     dm-verity in the user space.
-    bool hashtree_disabled =
-            ((AvbVBMetaImageFlags)vbmeta_header.flags & AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED);
-
     if (verification_disabled) {
         avb_handle->status_ = AvbHandleStatus::kVerificationDisabled;
-    } else if (hashtree_disabled) {
-        avb_handle->status_ = AvbHandleStatus::kHashtreeDisabled;
+    } else {
+        // Verifies vbmeta structs against the digest passed from bootloader in kernel cmdline.
+        std::unique_ptr<AvbVerifier> avb_verifier = AvbVerifier::Create();
+        if (!avb_verifier) {
+            LERROR << "Failed to create AvbVerifier";
+            return nullptr;
+        }
+        if (!avb_verifier->VerifyVbmetaImages(avb_handle->vbmeta_images_)) {
+            LERROR << "VerifyVbmetaImages failed";
+            return nullptr;
+        }
+
+        // Checks whether FLAGS_HASHTREE_DISABLED is set.
+        bool hashtree_disabled = ((AvbVBMetaImageFlags)vbmeta_header.flags &
+                                  AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED);
+        if (hashtree_disabled) {
+            avb_handle->status_ = AvbHandleStatus::kHashtreeDisabled;
+        }
     }
 
     LINFO << "Returning avb_handle with status: " << avb_handle->status_;

--- a/fs_mgr/libfs_avb/fs_avb.cpp
+++ b/fs_mgr/libfs_avb/fs_avb.cpp
@@ -242,7 +242,8 @@ AvbUniquePtr AvbHandle::LoadAndVerifyVbmeta(
     bool verification_disabled = ((AvbVBMetaImageFlags)vbmeta_header->flags &
                                   AVB_VBMETA_IMAGE_FLAGS_VERIFICATION_DISABLED);
     bool hashtree_disabled =
-            ((AvbVBMetaImageFlags)vbmeta_header->flags & AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED);
+            ((AvbVBMetaImageFlags)vbmeta_header->flags & AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED) ||
+            allow_verification_error;
     if (verification_disabled) {
         avb_handle->status_ = AvbHandleStatus::kVerificationDisabled;
     } else if (hashtree_disabled) {
@@ -460,7 +461,8 @@ AvbUniquePtr AvbHandle::Open() {
 
         // Checks whether FLAGS_HASHTREE_DISABLED is set.
         bool hashtree_disabled = ((AvbVBMetaImageFlags)vbmeta_header.flags &
-                                  AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED);
+                                  AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED) ||
+                                  allow_verification_error;
         if (hashtree_disabled) {
             avb_handle->status_ = AvbHandleStatus::kHashtreeDisabled;
         }

--- a/fs_mgr/libfs_avb/fs_avb.cpp
+++ b/fs_mgr/libfs_avb/fs_avb.cpp
@@ -242,8 +242,7 @@ AvbUniquePtr AvbHandle::LoadAndVerifyVbmeta(
     bool verification_disabled = ((AvbVBMetaImageFlags)vbmeta_header->flags &
                                   AVB_VBMETA_IMAGE_FLAGS_VERIFICATION_DISABLED);
     bool hashtree_disabled =
-            ((AvbVBMetaImageFlags)vbmeta_header->flags & AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED) ||
-            allow_verification_error;
+            ((AvbVBMetaImageFlags)vbmeta_header->flags & AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED);
     if (verification_disabled) {
         avb_handle->status_ = AvbHandleStatus::kVerificationDisabled;
     } else if (hashtree_disabled) {
@@ -459,8 +458,7 @@ AvbUniquePtr AvbHandle::Open() {
     //   - vbmeta struct in all partitions are still processed, just disable
     //     dm-verity in the user space.
     bool hashtree_disabled =
-            ((AvbVBMetaImageFlags)vbmeta_header.flags & AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED) ||
-            allow_verification_error;
+            ((AvbVBMetaImageFlags)vbmeta_header.flags & AVB_VBMETA_IMAGE_FLAGS_HASHTREE_DISABLED);
 
     if (verification_disabled) {
         avb_handle->status_ = AvbHandleStatus::kVerificationDisabled;


### PR DESCRIPTION
This allows some devices to boot with locked bootloader without needing to disable verity